### PR TITLE
Issue #26 - Support for Default Typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ To use this plugin, annotate any classes which may contain references with *@Jso
         String name;
         Person secretSanta;
     }
+
+### Usage with Default Typing
+
+If you are using [default typing](https://github.com/FasterXML/jackson-docs/wiki/JacksonPolymorphicDeserialization) to handle polymorphism there is a little more setup you will need. 
+In short, you need to supply an attribute to the serializer. 
+This attribute will signal that default typing is in play and specify the attribute name to use for expressing types (Usually this is `@class`). 
+Examples and important warnings can be seen in [the unit test](blob/master/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java) for DefaultTyping. Currently only NON_FINAL and EVERYTHING modes are supported.
+
+**WARNING:** Default typing modes other than NON_FINAL and EVERYTHING may appear to succeed when `.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)` is used **but actually cause buggy deserialization** in which objects may become duplicated.
+This is why only these two modes are currently supported (see note at end of `testRoundTrip()` in the unit test for details, enhancements welcome)
+
+
     
 ## Author
 

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGGenerator.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGGenerator.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerator;
  */
 public class JSOGGenerator extends ObjectIdGenerator<JSOGRef> {
 
-  public static final Object DEFAULT_TYPING_ATTRIBUTE = "JSOG_DEFAULT_TYPING_ATTRIBUTE";
+  public static final String DEFAULT_TYPING_ATTRIBUTE = "JSOG_DEFAULT_TYPING_ATTRIBUTE";
   private static final long serialVersionUID = 1L;
 
 	protected transient int _nextValue;

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGGenerator.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGGenerator.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerator;
  */
 public class JSOGGenerator extends ObjectIdGenerator<JSOGRef> {
 
-  public static final Object DEFAULT_TYPING = "JSOG_DEFAULT_TYPING_ATTRIBUTE";
+  public static final Object DEFAULT_TYPING_ATTRIBUTE = "JSOG_DEFAULT_TYPING_ATTRIBUTE";
   private static final long serialVersionUID = 1L;
 
 	protected transient int _nextValue;

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGGenerator.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGGenerator.java
@@ -11,7 +11,8 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerator;
  */
 public class JSOGGenerator extends ObjectIdGenerator<JSOGRef> {
 
-	private static final long serialVersionUID = 1L;
+  public static final Object DEFAULT_TYPING = "JSOG_DEFAULT_TYPING_ATTRIBUTE";
+  private static final long serialVersionUID = 1L;
 
 	protected transient int _nextValue;
     protected final Class<?> _scope;

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGGenerator.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGGenerator.java
@@ -52,7 +52,7 @@ public class JSOGGenerator extends ObjectIdGenerator<JSOGRef> {
 	public JSOGRef generateId(Object forPojo) {
         int id = _nextValue;
         ++_nextValue;
-        return new JSOGRef(id);
+        return new JSOGRef(id, forPojo);
 	}
 
     @Override

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRef.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRef.java
@@ -22,6 +22,7 @@ public final class JSOGRef
 	@JsonProperty(REF_KEY)
 	public String ref;
 
+	transient Object refTo;
 	/**
 	 * A flag we use to determine if this ref has already been serialized. Because jackson calls the same
 	 * code for serializing both ids and refs, we simply assume the first use is an id and all subsequent
@@ -35,8 +36,9 @@ public final class JSOGRef
 	}
 
 	/** */
-	public JSOGRef(int val) {
+	public JSOGRef(int val, Object refTo) {
 		this(Integer.toString(val));
+    this.refTo = refTo;
 	}
 
 	@Override

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefDeserializer.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefDeserializer.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
 /**
- * Knows how to take either form of a JSOGRef (string or {@ref:string} and convert it back into a JSOGRef.
+ * Knows how to take either form of a JSOGRef (string or {@code {@ref:string}}) and convert it back into a JSOGRef.
  *
  * @author Jeff Schnitzer <jeff@infohazard.org>
  */

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefDeserializer.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefDeserializer.java
@@ -40,9 +40,9 @@ public class JSOGRefDeserializer extends JsonDeserializer<JSOGRef>
 			if (p.currentToken() != JsonToken.VALUE_STRING) {
 				throw new IllegalStateException("@ref attribute should be followed by a value?");
 			}
-		String text = p.getText(); //grab our id
-		p.nextToken(); // consume END_OBJECT
-		return new JSOGRef(text);
+			String text = p.getText(); //grab our id
+			p.nextToken(); // consume END_OBJECT
+			return new JSOGRef(text);
 		} else {
 			throw new IllegalStateException("Unexpected Token Type:" + p.currentToken().name());
 		}

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefDeserializer.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefDeserializer.java
@@ -36,6 +36,11 @@ public class JSOGRefDeserializer extends JsonDeserializer<JSOGRef>
 		if (p.currentToken() == JsonToken.FIELD_NAME) {
 			// we are being called for { "@ref":"#" }
 			//   and starting here ------^
+			// Or in default typing we should get called for { "@class":"com.example.Thingy","@ref":"#" }
+			//   and be starting here --------------------------------------------------------^
+			//   because default typing will have consumed the type attribute already. See the javadoc for
+			//   com.fasterxml.jackson.databind.JsonDeserializer.deserialize(JsonParser, DeserializationContext)
+			//   which talks about this (yes that does seem slightly out of place, I'd guess it predates this method)
 			p.nextToken();
 			if (p.currentToken() != JsonToken.VALUE_STRING) {
 				throw new IllegalStateException("@ref attribute should be followed by a value?");

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefDeserializer.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefDeserializer.java
@@ -1,12 +1,13 @@
 package com.voodoodyne.jackson.jsog;
 
 
+import java.io.IOException;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
 /**
  * Knows how to take either form of a JSOGRef (string or {@ref:string} and convert it back into a JSOGRef.
@@ -16,7 +17,7 @@ import java.io.IOException;
 public class JSOGRefDeserializer extends JsonDeserializer<JSOGRef>
 {
 	@Override
-	public JSOGRef deserialize(JsonParser jp, DeserializationContext ctx) throws IOException, JsonProcessingException {
+	public JSOGRef deserialize(JsonParser jp, DeserializationContext ctx) throws IOException {
 		JsonNode node = ctx.readValue(jp, JsonNode.class);
 		if (node.isTextual()) {
 			return new JSOGRef(node.asText());
@@ -25,4 +26,27 @@ public class JSOGRefDeserializer extends JsonDeserializer<JSOGRef>
 		}
 	}
 
+	@Override
+	public Object deserializeWithType(JsonParser p, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+		// in the event of default typing, this gets called instead of deserialize above, and it seems to get
+		// called for each @id (the first case) and for each {"@ref":"#"} (the second case)
+		if (p.currentToken() == JsonToken.VALUE_STRING) {
+			return new JSOGRef(p.getText());
+		}
+		if (p.currentToken() == JsonToken.FIELD_NAME) {
+			// we are being called for { "@ref":"#" }
+			//   and starting here ------^
+			p.nextToken();
+			if (p.currentToken() != JsonToken.VALUE_STRING) {
+				throw new IllegalStateException("@ref attribute should be followed by a value?");
+			}
+		String text = p.getText(); //grab our id
+		p.nextToken(); // consume END_OBJECT
+		return new JSOGRef(text);
+		} else {
+			throw new IllegalStateException("Unexpected Token Type:" + p.currentToken().name());
+		}
+	}
 }
+
+

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
@@ -2,7 +2,6 @@ package com.voodoodyne.jackson.jsog;
 
 
 import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 
 /**
  * Knows how to take a JSOGRef and print it as @id or @ref as appropriate.
@@ -29,4 +30,11 @@ public class JSOGRefSerializer extends JsonSerializer<JSOGRef>
 		}
 	}
 
+// Side Note: This never gets called, so we cant rely on it despite the fact we need its equivalent in the
+// deserializer. I suspect ID serialization is not a first class citizen and jackson isn't expecting typing.
+//
+//	@Override
+//	public void serializeWithType(JSOGRef value, JsonGenerator gen, SerializerProvider serializers, TypeSerializer typeSer) throws IOException {
+//		super.serializeWithType(value, gen, serializers, typeSer);
+//	}
 }

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
@@ -18,7 +18,10 @@ public class JSOGRefSerializer extends JsonSerializer<JSOGRef>
 	public void serialize(JSOGRef value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
 		if (value.used) {
 			jgen.writeStartObject();
-			jgen.writeObjectField("@class", value.refTo.getClass().getName());
+			Object attribute = provider.getAttribute(JSOGGenerator.DEFAULT_TYPING);
+			if (attribute != null) {
+				jgen.writeObjectField(attribute.toString(), value.refTo.getClass().getName());
+			}
 			jgen.writeObjectField(JSOGRef.REF_KEY, value.ref);
 			jgen.writeEndObject();
 		} else {

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
@@ -4,7 +4,6 @@ package com.voodoodyne.jackson.jsog;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
@@ -16,9 +15,10 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 public class JSOGRefSerializer extends JsonSerializer<JSOGRef>
 {
 	@Override
-	public void serialize(JSOGRef value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+	public void serialize(JSOGRef value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
 		if (value.used) {
 			jgen.writeStartObject();
+			jgen.writeObjectField("@class", value.refTo.getClass().getName());
 			jgen.writeObjectField(JSOGRef.REF_KEY, value.ref);
 			jgen.writeEndObject();
 		} else {

--- a/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
+++ b/src/main/java/com/voodoodyne/jackson/jsog/JSOGRefSerializer.java
@@ -18,7 +18,7 @@ public class JSOGRefSerializer extends JsonSerializer<JSOGRef>
 	public void serialize(JSOGRef value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
 		if (value.used) {
 			jgen.writeStartObject();
-			Object attribute = provider.getAttribute(JSOGGenerator.DEFAULT_TYPING);
+			Object attribute = provider.getAttribute(JSOGGenerator.DEFAULT_TYPING_ATTRIBUTE);
 			if (attribute != null) {
 				jgen.writeObjectField(attribute.toString(), value.refTo.getClass().getName());
 			}

--- a/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
+++ b/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
@@ -108,6 +108,9 @@ public class Issue26Test {
     // but it wasn't easy to find. One can also set this directly when invoking the write
     // operations with mapper.writer().withAttribute(JSOGGenerator.DEFAULT_TYPING, "@class")
     // if single instantiation is important, but then you need to do it every time you write.
+    //
+    // Note: there IS a better way after https://github.com/FasterXML/jackson-databind/issues/3001
+    // but that requires 2.13.0+ jackson dependency.
     SerializationConfig config = mapper.getSerializationConfig()
         // obviously this attribute must be coordinated with the actual value used in the JSON
         // (could also be "@c" or a custom name depending on config)

--- a/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
+++ b/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
@@ -1,0 +1,88 @@
+package com.voodoodyne.jackson.jsog;
+
+import java.util.ArrayList;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import org.junit.Test;
+
+public class Issue26Test {
+
+  // @formatter:off
+  String TEST_JSON="[\"java.util.ArrayList\",[" +
+
+      "{" +
+        "\"@class\":\"com.voodoodyne.jackson.jsog.Issue26Test$Outer\"," +
+        "\"@id\":\"1\"," +
+        "\"inner\":{" +
+          "\"@class\":\"com.voodoodyne.jackson.jsog.Issue26Test$Inner\"," +
+          "\"@id\":\"2\"," +
+          "\"outer\":{" +
+            "\"@class\":\"com.voodoodyne.jackson.jsog.Issue26Test$Outer\"," + // <-- added for issue 26
+            "\"@ref\":\"1\"" +
+          "}" +
+        "}" +
+      "}," +
+
+      "{\"" +
+        "@class\":\"com.voodoodyne.jackson.jsog.Issue26Test$Inner\"," + // <-- added for issue 26
+        "\"@ref\":\"2\"}" +
+      "]]";
+
+  // @formatter:on
+  @Test
+  public void testDeserializeWithDefaultTyping() throws JsonProcessingException {
+    PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
+    ObjectMapper mapper = new ObjectMapper()
+        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING,
+            JsonTypeInfo.As.PROPERTY);
+    // also test this when jackson is upgraded...
+    // List<Object> target = mapper.readerForListOf(Object.class).readValue(json);
+    mapper.readValue(TEST_JSON, ArrayList.class);
+
+  }
+
+  // classes used in this test
+
+  @SuppressWarnings("unused")
+  @JsonIdentityInfo(generator = JSOGGenerator.class)
+  public static class Outer {
+    private Inner inner;
+
+    public Inner getInner() {
+      return inner;
+    }
+
+    public void setInner(Inner inner) {
+      this.inner = inner;
+    }
+  }
+
+  @SuppressWarnings("unused")
+  @JsonIdentityInfo(generator = JSOGGenerator.class)
+  public static class Inner {
+
+    private Outer outer;
+
+    Inner() {
+    }
+
+    public Inner(Outer outer) {
+      this.outer = outer;
+      outer.inner = this;
+    }
+
+    public Outer getOuter() {
+      return outer;
+    }
+
+    public void setOuter(Outer outer) {
+      this.outer = outer;
+    }
+  }
+
+
+}

--- a/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
+++ b/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
@@ -15,8 +15,8 @@ import org.testng.collections.Lists;
 
 public class Issue26Test {
 
-  // @formatter:off
-  String TEST_JSON="[\"java.util.ArrayList\",[" +
+  public static final String WIHOUT_DEFAULT_TYPING = "[{\"@id\":\"1\",\"inner\":{\"@id\":\"2\",\"outer\":{\"@ref\":\"1\"}}},{\"@ref\":\"2\"}]";
+  public static final String TEST_JSON="[\"java.util.ArrayList\",[" +
 
       "{" +
         "\"@class\":\"com.voodoodyne.jackson.jsog.Issue26Test$Outer\"," +
@@ -64,6 +64,27 @@ public class Issue26Test {
     String json = mapper.writeValueAsString(source);
 
     assertEquals(TEST_JSON,json);
+  }
+
+  // This will also be caught by various other tests, but for completeness of this issue
+  // we should also explicitly test it here with the same objects
+  @Test
+  public void testSerializeWithoutDefaultTypeing() throws JsonProcessingException {
+    Outer outer = new Outer();
+    Inner inner = new Inner(outer);
+    // Turn on type info
+    ObjectMapper mapper = new ObjectMapper();
+
+    List<Object> source = Lists.newArrayList(outer, inner);
+    String json = mapper.writeValueAsString(source);
+
+    // make sure our test json is truly valid - this round trips through a list of maps
+    @SuppressWarnings("rawtypes")
+    ArrayList l = mapper.readValue(WIHOUT_DEFAULT_TYPING, ArrayList.class);
+    assertEquals(WIHOUT_DEFAULT_TYPING, mapper.writeValueAsString(l));
+
+    // type info should not be written unless Default typing is on
+    assertEquals(WIHOUT_DEFAULT_TYPING,json);
   }
 
   // classes used in this test

--- a/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
+++ b/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
@@ -1,5 +1,7 @@
 package com.voodoodyne.jackson.jsog;
 
+import static com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping.EVERYTHING;
+import static com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping.NON_FINAL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
@@ -22,7 +24,7 @@ import org.testng.collections.Lists;
 @RunWith(Parameterized.class)
 public class Issue26Test {
 
-  public static final String WIHOUT_DEFAULT_TYPING = "[{\"@id\":\"1\",\"inner\":{\"@id\":\"2\",\"outer\":{\"@ref\":\"1\"}}},{\"@ref\":\"2\"}]";
+  public static final String WITHOUT_DEFAULT_TYPING = "[{\"@id\":\"1\",\"inner\":{\"@id\":\"2\",\"outer\":{\"@ref\":\"1\"}}},{\"@ref\":\"2\"}]";
 
   // @formatter:off
   public static final String TEST_JSON=
@@ -46,7 +48,7 @@ public class Issue26Test {
       "]]";
   // @formatter:on
 
-  private DefaultTyping defaultTyping;
+  private final DefaultTyping defaultTyping;
 
   public Issue26Test(DefaultTyping defaultTyping) {
     this.defaultTyping = defaultTyping;
@@ -65,8 +67,8 @@ public class Issue26Test {
     //    objects.add(new Object[]{DefaultTyping.NON_CONCRETE_AND_ARRAYS});
 
     // These work
-    objects.add(new Object[]{DefaultTyping.NON_FINAL});
-    objects.add(new Object[]{DefaultTyping.EVERYTHING});
+    objects.add(new Object[]{NON_FINAL});
+    objects.add(new Object[]{EVERYTHING});
     return objects;
   }
 
@@ -75,7 +77,7 @@ public class Issue26Test {
   public void testDeserializeWithDefaultTyping() throws JsonProcessingException {
     PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
     ObjectMapper mapper = new ObjectMapper()
-        .activateDefaultTyping(ptv, DefaultTyping.EVERYTHING,
+        .activateDefaultTyping(ptv, EVERYTHING,
             JsonTypeInfo.As.PROPERTY);
     System.out.println(defaultTyping);
     // also test this when jackson is upgraded...
@@ -112,6 +114,10 @@ public class Issue26Test {
         .withAttribute(JSOGGenerator.DEFAULT_TYPING_ATTRIBUTE, "@class");
 
     mapper = new ObjectMapper()
+        // FAIL_ON_UNKNOWN_PROPERTIES = false is dangerous if combined with any of
+        // JAVA_LANG_OBJECT, OBJECT_AND_NON_CONCRETE, NON_CONCRETE_AND_ARRAYS
+        // The final line of this test demonstrates that it can lead to duplication of objects.
+        // .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         .activateDefaultTyping(ptv, defaultTyping,
             JsonTypeInfo.As.PROPERTY).setConfig(config);
     List<Object> source = Lists.newArrayList(outer, inner);
@@ -125,6 +131,9 @@ public class Issue26Test {
     assertEquals(Outer.class, list.get(0).getClass()); // prove it's not a list of map objects
     assertEquals(Inner.class, list.get(1).getClass());
     assertSame(((Outer) list.get(0)).inner, list.get(1));
+
+    // This is critical. It fails when .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    // and any of JAVA_LANG_OBJECT, OBJECT_AND_NON_CONCRETE, NON_CONCRETE_AND_ARRAYS are used;
     assertSame(((Inner) list.get(1)).outer, list.get(0));
   }
 
@@ -135,7 +144,7 @@ public class Issue26Test {
     // Turn on type info
     PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
     ObjectMapper mapper = new ObjectMapper()
-        .activateDefaultTyping(ptv, DefaultTyping.EVERYTHING,
+        .activateDefaultTyping(ptv, EVERYTHING,
             JsonTypeInfo.As.PROPERTY);
     // sadly the following throws a null pointer exception
     // mapper.getSerializerProvider().setAttribute(JSOGGenerator.DEFAULT_TYPING, "@class");
@@ -143,7 +152,7 @@ public class Issue26Test {
     // probably there is a better way to do this but it wasn't easy to find quickly.
     SerializationConfig config = mapper.getSerializationConfig().withAttribute(JSOGGenerator.DEFAULT_TYPING_ATTRIBUTE, "@class");
     mapper = new ObjectMapper()
-        .activateDefaultTyping(ptv, DefaultTyping.EVERYTHING,
+        .activateDefaultTyping(ptv, EVERYTHING,
             JsonTypeInfo.As.PROPERTY).setConfig(config);
     List<Object> source = Lists.newArrayList(outer, inner);
     String json = mapper.writeValueAsString(source);
@@ -164,11 +173,11 @@ public class Issue26Test {
 
     // make sure our test json is truly valid - this round trips through a list of maps
     @SuppressWarnings("rawtypes")
-    ArrayList l = mapper.readValue(WIHOUT_DEFAULT_TYPING, ArrayList.class);
-    assertEquals(WIHOUT_DEFAULT_TYPING, mapper.writeValueAsString(l));
+    ArrayList l = mapper.readValue(WITHOUT_DEFAULT_TYPING, ArrayList.class);
+    assertEquals(WITHOUT_DEFAULT_TYPING, mapper.writeValueAsString(l));
 
     // type info should not be written unless Default typing is on
-    assertEquals(WIHOUT_DEFAULT_TYPING, json);
+    assertEquals(WITHOUT_DEFAULT_TYPING, json);
   }
 
   // classes used in this test

--- a/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
+++ b/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import org.junit.Test;
@@ -58,8 +59,14 @@ public class Issue26Test {
     ObjectMapper mapper = new ObjectMapper()
         .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING,
             JsonTypeInfo.As.PROPERTY);
+    // sadly the following throws a null pointer exception
+    // mapper.getSerializerProvider().setAttribute(JSOGGenerator.DEFAULT_TYPING, "@class");
 
-
+    // probably there is a better way to do this but it wasn't easy to find quickly.
+    SerializationConfig config = mapper.getSerializationConfig().withAttribute(JSOGGenerator.DEFAULT_TYPING, "@class");
+    mapper = new ObjectMapper()
+        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING,
+            JsonTypeInfo.As.PROPERTY).setConfig(config);
     List<Object> source = Lists.newArrayList(outer, inner);
     String json = mapper.writeValueAsString(source);
 

--- a/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
+++ b/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
@@ -1,6 +1,7 @@
 package com.voodoodyne.jackson.jsog;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,8 +47,13 @@ public class Issue26Test {
             JsonTypeInfo.As.PROPERTY);
     // also test this when jackson is upgraded...
     // List<Object> target = mapper.readerForListOf(Object.class).readValue(json);
-    mapper.readValue(TEST_JSON, ArrayList.class);
-
+    @SuppressWarnings("rawtypes")
+    ArrayList list = mapper.readValue(TEST_JSON, ArrayList.class);
+    assertEquals(2, list.size());
+    assertEquals(Outer.class, list.get(0).getClass()); // prove it's not a list of map objects
+    assertEquals(Inner.class, list.get(1).getClass());
+    assertSame(((Outer)list.get(0)).inner, list.get(1));
+    assertSame(((Inner)list.get(1)).outer, list.get(0));
   }
 
   @Test
@@ -63,13 +69,12 @@ public class Issue26Test {
     // mapper.getSerializerProvider().setAttribute(JSOGGenerator.DEFAULT_TYPING, "@class");
 
     // probably there is a better way to do this but it wasn't easy to find quickly.
-    SerializationConfig config = mapper.getSerializationConfig().withAttribute(JSOGGenerator.DEFAULT_TYPING, "@class");
+    SerializationConfig config = mapper.getSerializationConfig().withAttribute(JSOGGenerator.DEFAULT_TYPING_ATTRIBUTE, "@class");
     mapper = new ObjectMapper()
         .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING,
             JsonTypeInfo.As.PROPERTY).setConfig(config);
     List<Object> source = Lists.newArrayList(outer, inner);
     String json = mapper.writeValueAsString(source);
-
     assertEquals(TEST_JSON,json);
   }
 
@@ -132,6 +137,5 @@ public class Issue26Test {
       this.outer = outer;
     }
   }
-
 
 }

--- a/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
+++ b/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
@@ -4,22 +4,29 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.testng.collections.Lists;
 
+@RunWith(Parameterized.class)
 public class Issue26Test {
 
   public static final String WIHOUT_DEFAULT_TYPING = "[{\"@id\":\"1\",\"inner\":{\"@id\":\"2\",\"outer\":{\"@ref\":\"1\"}}},{\"@ref\":\"2\"}]";
-  public static final String TEST_JSON="[\"java.util.ArrayList\",[" +
 
+  // @formatter:off
+  public static final String TEST_JSON=
+    "[\"java.util.ArrayList\",[" +
       "{" +
         "\"@class\":\"com.voodoodyne.jackson.jsog.Issue26Test$Outer\"," +
         "\"@id\":\"1\"," +
@@ -37,14 +44,40 @@ public class Issue26Test {
         "@class\":\"com.voodoodyne.jackson.jsog.Issue26Test$Inner\"," + // <-- added for issue 26
         "\"@ref\":\"2\"}" +
       "]]";
-
   // @formatter:on
+
+  private DefaultTyping defaultTyping;
+
+  public Issue26Test(DefaultTyping defaultTyping) {
+    this.defaultTyping = defaultTyping;
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    ArrayList<Object[]> objects = new ArrayList<Object[]>();
+    // sadly these don't work I tried adding a second attribute to let us know which
+    // mode we are in, but adding @class in these cases throws an exception because
+    // @class is not expected in one place and not adding it throws exceptions
+    // when @class isn't found in another. There's some tricky subtlety in these formats
+    // relating to typing I haven't figured out
+    //    objects.add(new Object[]{DefaultTyping.JAVA_LANG_OBJECT});
+    //    objects.add(new Object[]{DefaultTyping.OBJECT_AND_NON_CONCRETE});
+    //    objects.add(new Object[]{DefaultTyping.NON_CONCRETE_AND_ARRAYS});
+
+    // These work
+    objects.add(new Object[]{DefaultTyping.NON_FINAL});
+    objects.add(new Object[]{DefaultTyping.EVERYTHING});
+    return objects;
+  }
+
+
   @Test
   public void testDeserializeWithDefaultTyping() throws JsonProcessingException {
     PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
     ObjectMapper mapper = new ObjectMapper()
-        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING,
+        .activateDefaultTyping(ptv, DefaultTyping.EVERYTHING,
             JsonTypeInfo.As.PROPERTY);
+    System.out.println(defaultTyping);
     // also test this when jackson is upgraded...
     // List<Object> target = mapper.readerForListOf(Object.class).readValue(json);
     @SuppressWarnings("rawtypes")
@@ -52,18 +85,57 @@ public class Issue26Test {
     assertEquals(2, list.size());
     assertEquals(Outer.class, list.get(0).getClass()); // prove it's not a list of map objects
     assertEquals(Inner.class, list.get(1).getClass());
-    assertSame(((Outer)list.get(0)).inner, list.get(1));
-    assertSame(((Inner)list.get(1)).outer, list.get(0));
+    assertSame(((Outer) list.get(0)).inner, list.get(1));
+    assertSame(((Inner) list.get(1)).outer, list.get(0));
   }
 
   @Test
-  public void testSerializeWithDefaultTypeing() throws JsonProcessingException {
+  public void testRoundTrip() throws JsonProcessingException {
+
     Outer outer = new Outer();
     Inner inner = new Inner(outer);
     // Turn on type info
     PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
     ObjectMapper mapper = new ObjectMapper()
-        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING,
+        .activateDefaultTyping(ptv, defaultTyping,
+            JsonTypeInfo.As.PROPERTY);
+    // sadly the following throws a null pointer exception
+    // mapper.getSerializerProvider().setAttribute(JSOGGenerator.DEFAULT_TYPING, "@class");
+
+    // probably there is a better way to do this without double instantiating the mapper,
+    // but it wasn't easy to find. One can also set this directly when invoking the write
+    // operations with mapper.writer().withAttribute(JSOGGenerator.DEFAULT_TYPING, "@class")
+    // if single instantiation is important, but then you need to do it every time you write.
+    SerializationConfig config = mapper.getSerializationConfig()
+        // obviously this attribute must be coordinated with the actual value used in the JSON
+        // (could also be "@c" or a custom name depending on config)
+        .withAttribute(JSOGGenerator.DEFAULT_TYPING_ATTRIBUTE, "@class");
+
+    mapper = new ObjectMapper()
+        .activateDefaultTyping(ptv, defaultTyping,
+            JsonTypeInfo.As.PROPERTY).setConfig(config);
+    List<Object> source = Lists.newArrayList(outer, inner);
+    String json = mapper.writeValueAsString(source);
+
+    // also test this when jackson is upgraded...
+    // List<Object> target = mapper.readerForListOf(Object.class).readValue(json);
+    @SuppressWarnings("rawtypes")
+    ArrayList list = mapper.readValue(json, ArrayList.class);
+    assertEquals(2, list.size());
+    assertEquals(Outer.class, list.get(0).getClass()); // prove it's not a list of map objects
+    assertEquals(Inner.class, list.get(1).getClass());
+    assertSame(((Outer) list.get(0)).inner, list.get(1));
+    assertSame(((Inner) list.get(1)).outer, list.get(0));
+  }
+
+  @Test
+  public void testSerializeWithDefaultTyping() throws JsonProcessingException {
+    Outer outer = new Outer();
+    Inner inner = new Inner(outer);
+    // Turn on type info
+    PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
+    ObjectMapper mapper = new ObjectMapper()
+        .activateDefaultTyping(ptv, DefaultTyping.EVERYTHING,
             JsonTypeInfo.As.PROPERTY);
     // sadly the following throws a null pointer exception
     // mapper.getSerializerProvider().setAttribute(JSOGGenerator.DEFAULT_TYPING, "@class");
@@ -71,11 +143,11 @@ public class Issue26Test {
     // probably there is a better way to do this but it wasn't easy to find quickly.
     SerializationConfig config = mapper.getSerializationConfig().withAttribute(JSOGGenerator.DEFAULT_TYPING_ATTRIBUTE, "@class");
     mapper = new ObjectMapper()
-        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING,
+        .activateDefaultTyping(ptv, DefaultTyping.EVERYTHING,
             JsonTypeInfo.As.PROPERTY).setConfig(config);
     List<Object> source = Lists.newArrayList(outer, inner);
     String json = mapper.writeValueAsString(source);
-    assertEquals(TEST_JSON,json);
+    assertEquals(TEST_JSON, json);
   }
 
   // This will also be caught by various other tests, but for completeness of this issue
@@ -96,7 +168,7 @@ public class Issue26Test {
     assertEquals(WIHOUT_DEFAULT_TYPING, mapper.writeValueAsString(l));
 
     // type info should not be written unless Default typing is on
-    assertEquals(WIHOUT_DEFAULT_TYPING,json);
+    assertEquals(WIHOUT_DEFAULT_TYPING, json);
   }
 
   // classes used in this test

--- a/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
+++ b/src/test/java/com/voodoodyne/jackson/jsog/Issue26Test.java
@@ -1,6 +1,9 @@
 package com.voodoodyne.jackson.jsog;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
+import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -8,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import org.junit.Test;
+import org.testng.collections.Lists;
 
 public class Issue26Test {
 
@@ -43,6 +47,23 @@ public class Issue26Test {
     // List<Object> target = mapper.readerForListOf(Object.class).readValue(json);
     mapper.readValue(TEST_JSON, ArrayList.class);
 
+  }
+
+  @Test
+  public void testSerializeWithDefaultTypeing() throws JsonProcessingException {
+    Outer outer = new Outer();
+    Inner inner = new Inner(outer);
+    // Turn on type info
+    PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
+    ObjectMapper mapper = new ObjectMapper()
+        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING,
+            JsonTypeInfo.As.PROPERTY);
+
+
+    List<Object> source = Lists.newArrayList(outer, inner);
+    String json = mapper.writeValueAsString(source);
+
+    assertEquals(TEST_JSON,json);
   }
 
   // classes used in this test


### PR DESCRIPTION
In this PR I have added partial support for default typing in NON_FINAL and EVERYTHING modes. 

This support is not perfect because the Jackson API is not making it easy for a serializer to discern exactly what the default typing mode, and class identifier property are. Default typing is enabled on the mapper directly and does not set feature flags that can be interrogated, nor was I able to find a means to heuristically determine such information. There wasn't even any obvious way to leverage reflection to dig out this information. This is quite disappointing because it does seem that this is something a serializer needs to take into account to produce legal output. It might be worth discussing this with the Jackson project to see if I've missed something or if there is a good way for them to improve this in future versions. I did a quick look on more recent versions and didn't find anything. I mostly focused on the version of Jackson currently specified by this project (2.10.3), since changing compatibility with versions is an additional burden, and probably should be done in it's own PR.

Nonetheless, by specifying an attribute visible in the mapping context for the writer, I am able to output class information.

What is supported in this PR:

- DefaultTyping.NON_FINAL
- DefaultTyping.EVERYTHING (this is deprecated by jackson, but central to the issue report)
- Fully qualified class names for type identification (i.e. "com.example.MySerializedClass")

What is no supported:

- Other modes such as JAVA_LANG_OBJECT,  OBJECT_AND_NON_CONCRETE, NON_CONCRETE_AND_ARRAYS
  - These modes seem to get caught in some sort of catch 22 where `@class` is not expected in some cases and required in others. No exception is thrown if we add .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false) but the output is not correct and some objects become duplicated, so I have aggresively documented against this combination. 
- Short class names (i.e. ".MySerializedClass") 
  - I experimented with passing in mode information and this information via additional attributes, and it's possible, but my difficulties with alternate modes left me disinclined to add the complexity for this at this time.

All unit tests pass, and I added a new test specific to Issue26 to document it and it's limitations README file was updated to provide guidance on how to enable this support.

During this investigation I also had some ideas on how to optimize the deserializer to avoid needless creation of an immediately garbage collectable JsonNode object and simplify the code for this feature slightly too, but that can be a follow on PR. 